### PR TITLE
Added a setting to check for whether or not the checkbox is checked a…

### DIFF
--- a/ranger/src/main/java/org/charmeck/trailofhistory/ranger/EmailPasswordActivity.java
+++ b/ranger/src/main/java/org/charmeck/trailofhistory/ranger/EmailPasswordActivity.java
@@ -34,19 +34,13 @@ public class EmailPasswordActivity extends BaseActivity {
 
     private static final String TAG = "EmailPassword";
 
-    //Preferences
-    private static final String CLTPREFERENCES = "CLTPREFERENCES";
-    private static final String REMEMBER_ID = "remember_id";
-    private static final String STORED_USERNAME = "stored_username";
-    //End Preferences
-
     @BindView(R.id.field_email) EditText mEmailField;
     @BindView(R.id.field_password) EditText mPasswordField;
     @BindView(R.id.bool_remember_id) CheckBox mRememberId;
 
     private FirebaseAuth mAuth;
-    private SharedPreferences mSharedPreferences;
     private boolean mRememberIdValue;
+    private PreferenceSaver preferenceSaver;
 
     public static Intent newInstance(Context context){
         Intent intent =  new Intent(context, EmailPasswordActivity.class);
@@ -60,15 +54,15 @@ public class EmailPasswordActivity extends BaseActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mSharedPreferences = getSharedPreferences(CLTPREFERENCES, MODE_PRIVATE);
-        mRememberIdValue = mSharedPreferences.getBoolean(REMEMBER_ID, false);
+        preferenceSaver = new SharedPreferencesSaver(getApplicationContext());
+        mRememberIdValue = preferenceSaver.isRememberId();
         setContentView(R.layout.activity_emailpassword);
         ButterKnife.bind(this);
 
         if (mRememberIdValue) {
             Log.d(TAG, "testing setting text and checkbox");
             mRememberId.setChecked(true);
-            mEmailField.setText(mSharedPreferences.getString(STORED_USERNAME, ""));
+            mEmailField.setText(preferenceSaver.getSavedUsername());
             mPasswordField.requestFocus();
         }
 
@@ -81,7 +75,7 @@ public class EmailPasswordActivity extends BaseActivity {
             return;
         }
 
-        storeCredentials(mSharedPreferences, email, mRememberId.isChecked());
+        preferenceSaver.storeCredentials(email, mRememberId.isChecked());
 
         showProgressDialog();
 
@@ -131,30 +125,6 @@ public class EmailPasswordActivity extends BaseActivity {
         return valid;
     }
 
-    /**
-     * This is used to store the credentials for the user.  This only stores the username and only
-     * if the rememeber Id option is valid.  Otherwise, it removes it from the shared preferences so
-     * in the event someone does turn on the switch, they do not get a previous stored value.
-     *
-     * @param sharedPreferences - This is the shared preferences for the application.  Intentionally
-     *                          passing in as a parameter for di in the future.
-     * @param email - The email of the user to be stored.
-     * @param rememberId - The boolean value of the checkbox so it can be stored for future use and
-     *                   to retrieve the email in the onCreate method.
-     */
-    private void storeCredentials(SharedPreferences sharedPreferences, String email, boolean rememberId) {
-        SharedPreferences.Editor editor = sharedPreferences.edit();
-        if(rememberId) {
-            Log.d(TAG, "storing username");
-            editor.putString(STORED_USERNAME, email).apply();
-            editor.putBoolean(REMEMBER_ID, true).apply();
-        }
-        else {
-            Log.d(TAG, "removing username");
-            editor.remove(STORED_USERNAME).apply();
-            editor.remove(REMEMBER_ID).apply();
-        }
-    }
 
     @OnClick(R.id.email_sign_in_button)
     public void onClick(View v) {

--- a/ranger/src/main/java/org/charmeck/trailofhistory/ranger/EmailPasswordActivity.java
+++ b/ranger/src/main/java/org/charmeck/trailofhistory/ranger/EmailPasswordActivity.java
@@ -7,12 +7,15 @@ package org.charmeck.trailofhistory.ranger;
  */
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.content.IntentCompat;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.Toast;
 
@@ -24,16 +27,26 @@ import com.google.firebase.auth.FirebaseAuth;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.OnCheckedChanged;
 import butterknife.OnClick;
 
 public class EmailPasswordActivity extends BaseActivity {
 
     private static final String TAG = "EmailPassword";
 
+    //Preferences
+    private static final String CLTPREFERENCES = "CLTPREFERENCES";
+    private static final String REMEMBER_ID = "remember_id";
+    private static final String STORED_USERNAME = "stored_username";
+    //End Preferences
+
     @BindView(R.id.field_email) EditText mEmailField;
     @BindView(R.id.field_password) EditText mPasswordField;
+    @BindView(R.id.bool_remember_id) CheckBox mRememberId;
 
     private FirebaseAuth mAuth;
+    private SharedPreferences mSharedPreferences;
+    private boolean mRememberIdValue;
 
     public static Intent newInstance(Context context){
         Intent intent =  new Intent(context, EmailPasswordActivity.class);
@@ -47,8 +60,17 @@ public class EmailPasswordActivity extends BaseActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        mSharedPreferences = getSharedPreferences(CLTPREFERENCES, MODE_PRIVATE);
+        mRememberIdValue = mSharedPreferences.getBoolean(REMEMBER_ID, false);
         setContentView(R.layout.activity_emailpassword);
         ButterKnife.bind(this);
+
+        if (mRememberIdValue) {
+            Log.d(TAG, "testing setting text and checkbox");
+            mRememberId.setChecked(true);
+            mEmailField.setText(mSharedPreferences.getString(STORED_USERNAME, ""));
+            mPasswordField.requestFocus();
+        }
 
         mAuth = FirebaseAuth.getInstance();
     }
@@ -58,6 +80,8 @@ public class EmailPasswordActivity extends BaseActivity {
         if (!validateForm()) {
             return;
         }
+
+        storeCredentials(mSharedPreferences, email, mRememberId.isChecked());
 
         showProgressDialog();
 
@@ -105,6 +129,31 @@ public class EmailPasswordActivity extends BaseActivity {
         }
 
         return valid;
+    }
+
+    /**
+     * This is used to store the credentials for the user.  This only stores the username and only
+     * if the rememeber Id option is valid.  Otherwise, it removes it from the shared preferences so
+     * in the event someone does turn on the switch, they do not get a previous stored value.
+     *
+     * @param sharedPreferences - This is the shared preferences for the application.  Intentionally
+     *                          passing in as a parameter for di in the future.
+     * @param email - The email of the user to be stored.
+     * @param rememberId - The boolean value of the checkbox so it can be stored for future use and
+     *                   to retrieve the email in the onCreate method.
+     */
+    private void storeCredentials(SharedPreferences sharedPreferences, String email, boolean rememberId) {
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        if(rememberId) {
+            Log.d(TAG, "storing username");
+            editor.putString(STORED_USERNAME, email).apply();
+            editor.putBoolean(REMEMBER_ID, true).apply();
+        }
+        else {
+            Log.d(TAG, "removing username");
+            editor.remove(STORED_USERNAME).apply();
+            editor.remove(REMEMBER_ID).apply();
+        }
     }
 
     @OnClick(R.id.email_sign_in_button)

--- a/ranger/src/main/java/org/charmeck/trailofhistory/ranger/EmailPasswordActivity.java
+++ b/ranger/src/main/java/org/charmeck/trailofhistory/ranger/EmailPasswordActivity.java
@@ -75,8 +75,6 @@ public class EmailPasswordActivity extends BaseActivity {
             return;
         }
 
-        preferenceSaver.storeCredentials(email, mRememberId.isChecked());
-
         showProgressDialog();
 
         // [START sign_in_with_email]
@@ -94,6 +92,7 @@ public class EmailPasswordActivity extends BaseActivity {
                             Toast.makeText(EmailPasswordActivity.this, "Authentication failed.",
                                     Toast.LENGTH_SHORT).show();
                         } else {
+                            preferenceSaver.storeCredentials(task.getResult().getUser().getEmail(), mRememberId.isChecked());
                             startActivity(MainActivity.newInstance(EmailPasswordActivity.this));
                             finish();
                         }
@@ -134,6 +133,14 @@ public class EmailPasswordActivity extends BaseActivity {
                 break;
             default:
                 break;
+        }
+    }
+
+    //This will remove the stored email instantly when the checkbox is changed.
+    @OnClick(R.id.bool_remember_id)
+    public void onCheckedChanged(View v) {
+        if(!((CheckBox)v).isChecked()) {
+            preferenceSaver.storeCredentials("", mRememberId.isChecked());
         }
     }
 }

--- a/ranger/src/main/java/org/charmeck/trailofhistory/ranger/PreferenceSaver.java
+++ b/ranger/src/main/java/org/charmeck/trailofhistory/ranger/PreferenceSaver.java
@@ -1,0 +1,19 @@
+package org.charmeck.trailofhistory.ranger;
+
+import android.content.Context;
+import android.os.Bundle;
+
+/**
+ * Created by alexandernohe on 8/14/16.
+ */
+public interface PreferenceSaver {
+
+
+    public void saveInstanceState(Bundle InstanceState);
+
+    public String getSavedUsername();
+
+    public boolean isRememberId();
+
+    public void storeCredentials(String email, boolean rememberId);
+}

--- a/ranger/src/main/java/org/charmeck/trailofhistory/ranger/SharedPreferencesSaver.java
+++ b/ranger/src/main/java/org/charmeck/trailofhistory/ranger/SharedPreferencesSaver.java
@@ -1,0 +1,56 @@
+package org.charmeck.trailofhistory.ranger;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.util.Log;
+
+/**
+ * Created by alexandernohe on 8/14/16.
+ */
+public class SharedPreferencesSaver implements PreferenceSaver {
+
+    private SharedPreferences mSharedPreferences;
+
+    private static final String TAG = "PREFERENCESAVER";
+
+    //Preferences
+    private static final String CLTPREFERENCES = "CLTPREFERENCES";
+    private static final String REMEMBER_ID = "remember_id";
+    private static final String STORED_USERNAME = "stored_username";
+    //End Preferences
+
+    public SharedPreferencesSaver(Context applicationContext) {
+        mSharedPreferences = applicationContext.getSharedPreferences(CLTPREFERENCES, Context.MODE_PRIVATE);
+    }
+
+    @Override
+    public void saveInstanceState(Bundle InstanceState) {
+     //No implementation yet.  Want to discuss with someone or someone else can implement this.
+    }
+
+    @Override
+    public String getSavedUsername() {
+        return mSharedPreferences.getString(STORED_USERNAME, "");
+    }
+
+    @Override
+    public boolean isRememberId() {
+        return mSharedPreferences.getBoolean(REMEMBER_ID, false);
+    }
+
+    @Override
+    public void storeCredentials(String email, boolean rememberId) {
+        SharedPreferences.Editor editor = mSharedPreferences.edit();
+        if(rememberId) {
+            Log.d(TAG, "storing username");
+            editor.putString(STORED_USERNAME, email).apply();
+            editor.putBoolean(REMEMBER_ID, true).apply();
+        }
+        else {
+            Log.d(TAG, "removing username");
+            editor.remove(STORED_USERNAME).apply();
+            editor.remove(REMEMBER_ID).apply();
+        }
+    }
+}

--- a/ranger/src/main/res/layout/activity_emailpassword.xml
+++ b/ranger/src/main/res/layout/activity_emailpassword.xml
@@ -58,6 +58,24 @@
                 android:theme="@style/ThemeOverlay.MyDarkButton" />
 
         </LinearLayout>
+        <LinearLayout
+            android:id="@+id/remember_id_area"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/email_password_buttons"
+            android:orientation="horizontal"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            >
+            <CheckBox
+                android:id="@+id/bool_remember_id"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/remember_id_swtich" />
+        </LinearLayout>
 
 
     </RelativeLayout>

--- a/ranger/src/main/res/values/strings.xml
+++ b/ranger/src/main/res/values/strings.xml
@@ -19,5 +19,6 @@
     <string name="save">Save</string>
 
     <string name="error_required">Required.</string>
+    <string name="remember_id_swtich">Remember Email</string>
 
 </resources>


### PR DESCRIPTION
## Added a setting to check for whether or not the checkbox is checked and storing to shared preferences.

This should resolve #7 .

What I did here was I added a method to check whether or not the box was checked and if it was store the values to shared preferences and if it wasn't, delete it from shared preferences entirely.

```java
private void storeCredentials(SharedPreferences sharedPreferences, String email, boolean rememberId) {
        SharedPreferences.Editor editor = sharedPreferences.edit();
        if(rememberId) {
            Log.d(TAG, "storing username");
            editor.putString(STORED_USERNAME, email).apply();
            editor.putBoolean(REMEMBER_ID, true).apply();
        }
        else {
            Log.d(TAG, "removing username");
            editor.remove(STORED_USERNAME).apply();
            editor.remove(REMEMBER_ID).apply();
        }
    }
```

I passed Shared Preferences in as a parameter so we could:
* Use dagger for dependency injection
* Use it in unit testing

I do not have a great grasp on either of the above concepts, however, I believe that this method is written to help make this easier when that time comes without the requirement for lots of refactoring.  

Additionally, I made an update to update the UI after checking in shared preferences whether or not the saved username option was checked.  This looks like:

```java
if (mRememberIdValue) {
            Log.d(TAG, "testing setting text and checkbox");
            mRememberId.setChecked(true);
            mEmailField.setText(mSharedPreferences.getString(STORED_USERNAME, ""));
            mPasswordField.requestFocus();
        }
```

Again, I am not sure if this would follow butterknife's best practices as this is still foreign to me as well.

I look forward to any questions, comments, concerns, haikus, limericks, or suggestions.  Looking forward to learning with you all.

Thanks 👾 