### PR TITLE
modify Control Up/Back flow to main List

### DIFF
--- a/ranger/src/main/java/org/charmeck/trailofhistory/ranger/DetailPointOfInterestActivity.java
+++ b/ranger/src/main/java/org/charmeck/trailofhistory/ranger/DetailPointOfInterestActivity.java
@@ -27,6 +27,7 @@ public class DetailPointOfInterestActivity extends AppCompatActivity {
     public static Intent newInstance(Context context, PointOfInterest pointOfInterest){
         Intent intent =  new Intent(context, DetailPointOfInterestActivity.class);
         intent.putExtra(KEY_POI, pointOfInterest);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP); // Control Up/Back flow to main List
         return intent;
     }
 


### PR DESCRIPTION
Added Intent flag, "FLAG_ACTIVITY_CLEAR_TOP" to fix odd flow after editing a POI. 

Description:
After editing a POI, using the UP button would return the user to the detail activity and properly reflect the revised POI. Clicking UP again returns the user to the main List as expected. 

However, if using the Back button after editing, the user would first return to a detail activity showing the revised POI, and another click on Back would take them to a previous detail activity showing the unedited POI. A third touch on Back returned them to the main List as expected.

The Back button and Up button both produce the same behavior now.
