### PR TITLE
- Separating the app and ranger connected device tests (+6 squashed c…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,11 @@ android:
     - tools
     - platform-tools
 
-
-
     # The BuildTools version used by your project
     - build-tools-24.0.2
 
     # The SDK version used to compile your project
     - android-24
-    - android-22
 
     # Additional components
     - extra-google-google_play_services
@@ -25,8 +22,7 @@ android:
 
     # Specify at least one system image,
     # if you need to run emulator(s) during your tests
-    - sys-img-armeabi-v7a-android-22
-    #- sys-img-x86-android-24
+    - sys-img-armeabi-v7a-android-19
 
   licenses:
     - 'android-sdk-preview-license-.+'
@@ -34,6 +30,14 @@ android:
     - 'google-gdk-license-.+'
 script:
   - ./build.sh
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 
 notifications:
   slack: cltmobilemeetup:eIKxudoK0MDC6hBw7zkhxByT

--- a/build.sh
+++ b/build.sh
@@ -17,9 +17,11 @@ fi
 ./gradlew check -Dpre-dex=false
 
 # Emulator Management: Create, Start and Wait
-echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
-emulator -avd test -no-audio -no-window &
+echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a
+echo "Emulator creation finished"
+emulator -avd test -no-window &
 android-wait-for-emulator
 adb shell input keyevent 82 &
 
-./gradlew connectedAndroidTest
+./gradlew app:connectedAndroidTest
+./gradlew ranger:connectedAndroidTest


### PR DESCRIPTION
…ommits)

Squashed commits:
[05196d2] - Trying another emulator
[0ec1ea8] - Trying emulator without audio option
[f298e32] - Updating travis build, added caches
[888c3be] - Testing another emulator
[ac99d46] - Switching to ARM emulator as x86 does not work in a container build
[55fd266] - Testing android-24 emulator